### PR TITLE
Improved errors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,10 @@
+use crate::{error::TestError, TestResult};
+use colored::Colorize;
 use std::path::PathBuf;
 
 pub struct TestConfig {
     /// The binary path to your program, typically "target/debug/myprogram"
-    pub binary_path: String,
+    pub binary_path: PathBuf,
 
     /// The path to the subdirectory containing your tests. This subdirectory will be
     /// searched recursively for all files.
@@ -105,7 +107,11 @@ impl TestConfig {
     ///
     /// If you want to change these default keywords you can also create a TestConfig
     /// via `TestConfig::with_custom_keywords` which will allow you to specify each.
-    pub fn new(binary_path: &str, test_path: &str, test_line_prefix: &str) -> TestConfig {
+    pub fn new<Binary, Tests>(binary_path: Binary, test_path: Tests, test_line_prefix: &str) -> TestResult<TestConfig>
+    where
+        Binary: Into<PathBuf>,
+        Tests: Into<PathBuf>,
+    {
         TestConfig::with_custom_keywords(
             binary_path,
             test_path,
@@ -124,17 +130,33 @@ impl TestConfig {
     ///
     /// If you don't want to change any of the defaults, you can use `TestConfig::new` to construct
     /// a TestConfig with the default keywords (which are listed in its documentation).
-    pub fn with_custom_keywords(binary_path: &str, test_path: &str, test_line_prefix: &str,
+    pub fn with_custom_keywords<Binary, Tests>(binary_path: Binary, test_path: Tests, test_line_prefix: &str,
                                 test_args_prefix: &str, test_stdout_prefix: &str,
-                                test_stderr_prefix: &str, test_exit_status_prefix: &str) -> TestConfig {
-        TestConfig {
-            binary_path:             binary_path.to_string(),
-            test_path:               PathBuf::from(test_path),
-            test_line_prefix:        test_line_prefix.to_string(),
-            test_args_prefix:        test_line_prefix.to_string() + test_args_prefix,
-            test_stdout_prefix:      test_line_prefix.to_string() + test_stdout_prefix,
-            test_stderr_prefix:      test_line_prefix.to_string() + test_stderr_prefix,
-            test_exit_status_prefix: test_line_prefix.to_string() + test_exit_status_prefix,
+                                test_stderr_prefix: &str, test_exit_status_prefix: &str) -> TestResult<TestConfig>
+    where
+        Binary: Into<PathBuf>,
+        Tests: Into<PathBuf>,
+    {
+        let (binary_path, test_path) = (binary_path.into(), test_path.into());
+
+        if !test_path.exists() {
+            println!("{}", format!("the given test path '{}' does not exist", test_path.display()).red());
+
+            Err(TestError::MissingTests(test_path))
+        } else if !test_path.is_dir() {
+            println!("{}", format!("the given test path '{}' is not a directory", test_path.display()).red());
+
+            Err(TestError::ExpectedDirectory(test_path))
+        } else {
+            Ok(TestConfig {
+                binary_path:             binary_path,
+                test_path:               test_path,
+                test_line_prefix:        test_line_prefix.to_string(),
+                test_args_prefix:        test_line_prefix.to_string() + test_args_prefix,
+                test_stdout_prefix:      test_line_prefix.to_string() + test_stdout_prefix,
+                test_stderr_prefix:      test_line_prefix.to_string() + test_stderr_prefix,
+                test_exit_status_prefix: test_line_prefix.to_string() + test_exit_status_prefix,
+            })
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,17 +1,25 @@
 use std::fmt;
 use std::error::Error;
+use std::path::PathBuf;
 
 #[derive(Debug)]
 pub enum TestError {
     ExpectedOutputDiffers,
     IoError(std::io::Error),
     ErrorParsingExitStatus(std::num::ParseIntError),
+    MissingTests(PathBuf),
+    ExpectedDirectory(PathBuf),
 }
 
-// This isn't displayed when running tests via 'cargo test' anyway
 impl fmt::Display for TestError {
-    fn fmt(&self, _: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        Ok(())
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Self::ExpectedOutputDiffers => f.write_str("The expected test output differs"),
+            Self::IoError(err) => fmt::Display::fmt(err, f),
+            Self::ErrorParsingExitStatus(err) => write!(f, "Error parsing exit status: {}", err),
+            Self::MissingTests(path) => write!(f, "Failed to locate test files {}", path.display()),
+            Self::ExpectedDirectory(path) => write!(f, "The path given for test files should be a directory {}", path.display()),
+        }
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,6 +2,6 @@ use goldentests::{ TestConfig, TestResult };
 
 #[test]
 fn run_goldentests() -> TestResult<()> {
-    let config = TestConfig::new("python", "examples", "# ");
+    let config = TestConfig::new("python", "examples", "# ")?;
     config.run_tests()
 }


### PR DESCRIPTION
* Binary paths are now treated as `PathBuf`s instead of `Strings`
* Used generics in `TestConfig::new` and `TestConfig::with_custom_keywords` for better ergonomics
* An error is now returned if the given test path doesn't exist
* An error is now returned if the given test path isn't a directory
* While running tests status is now printed out for better feedback

Running with `cargo test -- --nocapture` now gives this output:

* `ok` is highlighted green, it'll be replaced by a red `failed` if the test fails
* `golden` is highlighted in yellow/gold, behavior hasn't changed there
* `3 passing` is green, `0 failing` is red

```sh
goldentesting 'examples\all_keywords.py'... ok
goldentesting 'examples\multiline.py'... ok
goldentesting 'examples\tab_difference.py'... ok
ran 3 golden tests with 3 passing and 0 failing
```

I would have added verification on the target binary, but that broke all the existing tests since they use python off the current path. More complex logic could be added that checks `PATH` (and equivalents) to figure out if the requested executable both exists and is an executable, but I thought that may be a bit much for one PR. Currently the behavior on that side is the same, if the file doesn't exist you get an IO error 