### PR TITLE
Switch diff crate to `similar`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ documentation = "https://docs.rs/goldentests"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-colored = "1.9"
+colored = "2.0.0"
 difference = "2.0.0"
-shlex = "0.1.1"
+shlex = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ documentation = "https://docs.rs/goldentests"
 
 [dependencies]
 colored = "2.0.0"
-difference = "2.0.0"
 shlex = "1.0.0"
+similar = "1.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub use error::TestError;
 use diff_printer::DiffPrinter;
 
 use colored::Colorize;
-use difference::Changeset;
+use similar::TextDiff;
 use shlex;
 
 use std::fs::File;
@@ -189,9 +189,8 @@ fn check_for_differences_in_stream(name: &str, path: &Path, stream: &[u8], expec
     let output = output_string.trim();
     let expected = expected.trim();
 
-    let differences = Changeset::new(expected, output, "\n");
-    let distance = differences.distance;
-    if distance != 0 {
+    let differences = TextDiff::from_lines(expected, output);
+    if differences.ratio() != 1.0 {
         println!("\n{}: Actual {} differs from expected {}:\n{}",
             path.to_string_lossy().bright_yellow(), name, name, DiffPrinter(differences));
         1


### PR DESCRIPTION
`cargo-audit` flags the `difference` crate as unmaintained ([advisory][RUSTSEC-2020-0095]). This PR replaces the flagged crate with the `similar` crate, which the advisory mentions as an alternative. It also changes the diff format to always highlight the background of a change.

[RUSTSEC-2020-0095]: https://rustsec.org/advisories/RUSTSEC-2020-0095