### PR TITLE
Add flag that overwrites the tests with the current output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 Cargo.lock
 .vscode
-overwrite_tests/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 .vscode
+overwrite_tests/

--- a/README.md
+++ b/README.md
@@ -137,8 +137,10 @@ Here is the full set of keywords goldentests looks for in the file:
 You can even configure the specific keywords used if you want. For any further information,
 check out goldentest's documentation [here](https://docs.rs/goldentests).
 
-### Update all tests with current output
-Enabling `overwrite_tests` will overwrite all failing tests with the output given when running them.
-One use is automatically porting old tests. If you have your golden-tests checked into version control you can easily review the changes afterwards.
-
-To enable pass the `--overwrite` flag or set the `overwrite_tests` field to `true`. 
+### Automatically updating tests
+Optionally, tests can be automatically updated by passing the `--overwrite`
+flag when running goldentests as a standalone program, or by setting the
+`overwrite_tests` flag when running as a rust library. Doing this will update
+the expected output in each file so that it matches the actual output. Since
+this is all automatic, make sure to manually review any changes before using
+this flag.

--- a/README.md
+++ b/README.md
@@ -132,5 +132,14 @@ Here is the full set of keywords goldentests looks for in the file:
 - `expected exit status: [i32]`: If specified, goldentests will issue an error if the exit status differs
   to what is expected. Defaults to `None` (exit status is ignored by default).
 
+
+
 You can even configure the specific keywords used if you want. For any further information,
 check out goldentest's documentation [here](https://docs.rs/goldentests).
+
+### Update all tests with current output
+Set the `overwrite_tests` field in the config if you're running using cargo.
+The standalone executable checks for the flag `--overwrite` or the environment variable `GOLDENTEST_OVERWRITE`.
+
+`overwrite tests`: If you want to update all your tests to match the current output, the `overwrite_tests` flag is for you.
+  

--- a/README.md
+++ b/README.md
@@ -138,8 +138,7 @@ You can even configure the specific keywords used if you want. For any further i
 check out goldentest's documentation [here](https://docs.rs/goldentests).
 
 ### Update all tests with current output
-Set the `overwrite_tests` field in the config if you're running using cargo.
-The standalone executable checks for the flag `--overwrite` or the environment variable `GOLDENTEST_OVERWRITE`.
+Enabling `overwrite_tests` will overwrite all failing tests with the output given when running them.
+One use is automatically porting old tests. If you have your golden-tests checked into version control you can easily review the changes afterwards.
 
-`overwrite tests`: If you want to update all your tests to match the current output, the `overwrite_tests` flag is for you.
-  
+To enable pass the `--overwrite` flag or set the `overwrite_tests` field to `true`. 

--- a/examples/all_keywords.py
+++ b/examples/all_keywords.py
@@ -6,7 +6,7 @@ sys.exit(3)
 
 # args: -c 'print("test"); exec(open("examples/all_keywords.py").read())'
 # expected exit status: 3
-# expected stdout:test
+# expected stdout: test
 
-# expected stderr:error!
+# expected stderr: error!
 

--- a/examples/all_keywords.py
+++ b/examples/all_keywords.py
@@ -6,6 +6,7 @@ sys.exit(3)
 
 # args: -c 'print("test"); exec(open("examples/all_keywords.py").read())'
 # expected exit status: 3
-# expected stdout: test
+# expected stdout:test
 
-# expected stderr: error!
+# expected stderr:error!
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,10 @@ pub struct TestConfig {
     /// // expected exit status: 0
     /// ```
     pub test_exit_status_prefix: String,
+
+    /// Flag the current output as correct and regenerate the test files. This assumes the order of
+    /// the `goldenfiles` sections can be moved around.
+    pub overwrite_tests: bool,
 }
 
 impl TestConfig {
@@ -121,6 +125,7 @@ impl TestConfig {
             "expected stdout:",
             "expected stderr:",
             "expected exit status:",
+            false,
         )
     }
 
@@ -139,6 +144,7 @@ impl TestConfig {
         test_stdout_prefix: &str,
         test_stderr_prefix: &str,
         test_exit_status_prefix: &str,
+        overwrite_tests: bool,
     ) -> TestResult<TestConfig>
     where
         Binary: Into<PathBuf>,
@@ -172,6 +178,7 @@ impl TestConfig {
                 test_stderr_prefix: prefixed(test_stderr_prefix),
                 test_exit_status_prefix: prefixed(test_exit_status_prefix),
                 test_line_prefix,
+                overwrite_tests,
             })
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,7 +56,7 @@ impl fmt::Display for InnerTestError {
             }
             InnerTestError::TestUpdated { path, errors } => {
                 for (i, error) in errors.iter().enumerate() {
-                    write!(f, "{}: Updated {}", s(path), error)?;
+                    write!(f, "{} - UPDATED:  {}", s(path), error)?;
                     if i + 1 != errors.len() {
                         writeln!(f)?;
                     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,7 @@ impl Error for TestError {}
 // Inner test errors shouldn't be visible to the end-user,
 // they'll all be reported internally after running the tests
 pub(crate) enum InnerTestError {
+    TestUpdated { path: PathBuf, errors: Vec<String> },
     TestFailed { path: PathBuf, errors: Vec<String> },
     IoError(PathBuf, std::io::Error),
     CommandError(PathBuf, std::process::Command, std::io::Error),
@@ -47,6 +48,15 @@ impl fmt::Display for InnerTestError {
             InnerTestError::TestFailed { path, errors } => {
                 for (i, error) in errors.iter().enumerate() {
                     write!(f, "{}: {}", s(path), error)?;
+                    if i + 1 != errors.len() {
+                        writeln!(f)?;
+                    }
+                }
+                Ok(())
+            }
+            InnerTestError::TestUpdated { path, errors } => {
+                for (i, error) in errors.iter().enumerate() {
+                    write!(f, "{}: Updated {}", s(path), error)?;
                     if i + 1 != errors.len() {
                         writeln!(f)?;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,6 @@ struct Args {
 
     #[clap(
         long,
-        default_value = false,
         help = "Accept what the current output, update the files to match this"
     )]
     overwrite: bool,
@@ -64,7 +63,7 @@ fn main() {
         &args.stdout_prefix,
         &args.stderr_prefix,
         &args.exit_status_prefix,
-        args.overwrite || env::var("GOLDENTEST_OVERWRITE").is_ok(),
+        args.overwrite || std::env::var("GOLDENTEST_OVERWRITE").is_ok(),
     ) {
         Ok(config) => config,
         Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,13 @@ struct Args {
         help = "The program to run for each test file"
     )]
     exit_status_prefix: String,
+
+    #[clap(
+        long,
+        default_value = false,
+        help = "Accept what the current output, update the files to match this"
+    )]
+    overwrite: bool,
 }
 
 fn main() {
@@ -57,6 +64,7 @@ fn main() {
         &args.stdout_prefix,
         &args.stderr_prefix,
         &args.exit_status_prefix,
+        args.overwrite || env::var("GOLDENTEST_OVERWRITE").is_ok(),
     ) {
         Ok(config) => config,
         Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn main() {
         &args.stdout_prefix,
         &args.stderr_prefix,
         &args.exit_status_prefix,
-        args.overwrite || std::env::var("GOLDENTEST_OVERWRITE").is_ok(),
+        args.overwrite,
     ) {
         Ok(config) => config,
         Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ struct Args {
 
     #[clap(
         long,
-        help = "Accept what the current output, update the files to match this"
+        help = "Update the expected output of each test file to match the actual output"
     )]
     overwrite: bool,
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -333,7 +333,7 @@ impl TestConfig {
             }
         }
 
-        if self.overwrite_tests {
+        if !self.overwrite_tests {
             println!(
                 "ran {} {} tests with {} and {}\n",
                 total_tests,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -178,7 +178,6 @@ fn overwrite_test(test_path: &PathBuf, config: &TestConfig, output: &Output, tes
             file.write_all(line)?;
             writeln!(file, "")?;
         }
-        writeln!(file, "")?;
     }
 
     // Doesn't handle \r correctly!
@@ -192,7 +191,6 @@ fn overwrite_test(test_path: &PathBuf, config: &TestConfig, output: &Output, tes
             file.write_all(line)?;
             writeln!(file, "")?;
         }
-        writeln!(file, "")?;
     }
     Ok(())
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -290,7 +290,7 @@ impl TestConfig {
                         overwrite_test(&file, self, &output, &test)
                             .map_err(|err| InnerTestError::IoError(file.to_owned(), err))?;
 
-                        Err(InnerTestError::TestUpdated { path, errors })?;
+                        return Err(InnerTestError::TestUpdated { path, errors });
                     }
                 }
                 Ok(())
@@ -336,7 +336,7 @@ impl TestConfig {
             format!("{} passing", total_tests - failing_tests).green(),
             format!("{} failing", failing_tests).red(),
             if updated_tests != 0 {
-                format!(" - {} updated", failing_tests)
+                format!(" - {} updated", updated_tests)
             } else {
                 String::new()
             }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -180,7 +180,7 @@ fn overwrite_test(test_path: &PathBuf, config: &TestConfig, output: &Output, tes
     // Doesn't handle \r correctly!
     if output.stderr.len() != 0 {
         writeln!(file, "{}", config.test_stderr_prefix)?;
-        for line in output.stdout.split(|c| *c == '\n' as u8) {
+        for line in output.stderr.split(|c| *c == '\n' as u8) {
             file.write_all(config.test_line_prefix.as_bytes())?;
             file.write_all(line)?;
             writeln!(file, "")?;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -162,7 +162,7 @@ fn write_expected_output_for_stream(file: &mut File, prefix: &str, marker: &str,
         0 => Ok(()),
         // If the line is short and nice, write that line
         1 if lines[0].len() < 80 => {
-            write!(file, "{}", marker)?;
+            write!(file, "{} ", marker)?;
             file.write_all(expected)?;
             writeln!(file, "")
         }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -336,26 +336,27 @@ impl TestConfig {
         for result in &outputs {
             match result {
                 Ok(_) => {}
-                Err(error) => {
-                    match error {
-                        InnerTestError::TestUpdated { .. } => {
-                            updated_tests += 1;
-                        }
-
-                        InnerTestError::TestFailed { .. } => {
-                            can_be_fixed_with_overwrite_tests += 1;
-                            failing_tests += 1;
-                        }
-
-                        InnerTestError::IoError(_, _)
-                        | InnerTestError::CommandError(_, _, _)
-                        | InnerTestError::ErrorParsingExitStatus(_, _, _)
-                        | InnerTestError::ErrorParsingArgs(_, _) => {
-                            failing_tests += 1;
-                        }
-                    }
-                    eprintln!("{}", error);
+                Err(InnerTestError::TestUpdated { .. }) => {
+                    updated_tests += 1;
                 }
+
+                Err(InnerTestError::TestFailed { .. }) => {
+                    can_be_fixed_with_overwrite_tests += 1;
+                    failing_tests += 1;
+                }
+
+                Err(
+                    InnerTestError::IoError(_, _)
+                    | InnerTestError::CommandError(_, _, _)
+                    | InnerTestError::ErrorParsingExitStatus(_, _, _)
+                    | InnerTestError::ErrorParsingArgs(_, _),
+                ) => {
+                    failing_tests += 1;
+                }
+            }
+
+            if let Err(err) = result {
+                eprintln!("{}", err)
             }
         }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -170,10 +170,7 @@ fn overwrite_test(test_path: &PathBuf, config: &TestConfig, output: &Output, tes
     // Doesn't handle \r correctly!
     if output.stdout.len() != 0 {
         writeln!(file, "{}", config.test_stdout_prefix)?;
-        for line in output.stdout.split(|c| *c == 0x0A) {
-            if line.is_empty() {
-                continue;
-            }
+        for line in output.stdout.split(|c| [*c] == "\n".as_bytes()) {
             file.write_all(config.test_line_prefix.as_bytes())?;
             file.write_all(line)?;
             writeln!(file, "")?;
@@ -183,10 +180,7 @@ fn overwrite_test(test_path: &PathBuf, config: &TestConfig, output: &Output, tes
     // Doesn't handle \r correctly!
     if output.stderr.len() != 0 {
         writeln!(file, "{}", config.test_stderr_prefix)?;
-        for line in output.stderr.split(|c| *c == 0x0A) {
-            if line.is_empty() {
-                continue;
-            }
+        for line in output.stderr.split(|c| [*c] == "\n".as_bytes()) {
             file.write_all(config.test_line_prefix.as_bytes())?;
             file.write_all(line)?;
             writeln!(file, "")?;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -170,7 +170,7 @@ fn overwrite_test(test_path: &PathBuf, config: &TestConfig, output: &Output, tes
     // Doesn't handle \r correctly!
     if output.stdout.len() != 0 {
         writeln!(file, "{}", config.test_stdout_prefix)?;
-        for line in output.stdout.split(|c| [*c] == "\n".as_bytes()) {
+        for line in output.stdout.split(|c| *c == '\n' as u8) {
             file.write_all(config.test_line_prefix.as_bytes())?;
             file.write_all(line)?;
             writeln!(file, "")?;
@@ -180,7 +180,7 @@ fn overwrite_test(test_path: &PathBuf, config: &TestConfig, output: &Output, tes
     // Doesn't handle \r correctly!
     if output.stderr.len() != 0 {
         writeln!(file, "{}", config.test_stderr_prefix)?;
-        for line in output.stderr.split(|c| [*c] == "\n".as_bytes()) {
+        for line in output.stdout.split(|c| *c == '\n' as u8) {
             file.write_all(config.test_line_prefix.as_bytes())?;
             file.write_all(line)?;
             writeln!(file, "")?;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -160,6 +160,7 @@ fn write_expected_output_for_stream(file: &mut File, prefix: &str, marker: &str,
     match lines.len() {
         // Don't write if there's nothing to write
         0 => Ok(()),
+        1 if lines[0].len() == 0 => Ok(()),
         // If the line is short and nice, write that line
         1 if lines[0].len() < 80 => {
             write!(file, "{} ", marker)?;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -156,7 +156,6 @@ fn overwrite_test(test_path: &PathBuf, config: &TestConfig, output: &Output, tes
 
     if !test.command_line_args.is_empty() {
         writeln!(file, "{}{}", config.test_args_prefix, test.command_line_args)?;
-        writeln!(file, "")?;
     }
 
     if Some(0) != output.status.code() {
@@ -293,7 +292,7 @@ impl TestConfig {
                         return Err(InnerTestError::TestUpdated { path, errors });
                     }
                 }
-                Ok(())
+                differences
             })
             .collect();
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -128,7 +128,7 @@ fn parse_test(test_path: &Path, config: &TestConfig) -> InnerTestResult<Test> {
             }
         } else {
             // Both expected_stdout and expected_stderr need a blank line at the end,
-            // strip that out.
+            // the order here implicitly skips that newline.
             if state == TestParseState::Neutral {
                 append_line(&mut rest, line);
             }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -180,7 +180,6 @@ fn write_expected_output_for_stream(file: &mut File, prefix: &str, marker: &str,
     }
 }
 
-
 fn overwrite_test(test_path: &PathBuf, config: &TestConfig, output: &Output, test: &Test) -> std::io::Result<()> {
     // Maybe copy the file so we don't remove it if we fail here?
     let mut file = File::create(test_path)?;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -189,7 +189,7 @@ fn overwrite_test(test_path: &PathBuf, config: &TestConfig, output: &Output, tes
     writeln!(file, "")?;
 
     if !test.command_line_args.is_empty() {
-        writeln!(file, "{} {}", config.test_args_prefix, test.command_line_args)?;
+        writeln!(file, "{} {}", config.test_args_prefix, test.command_line_args.trim())?;
     }
 
     if Some(0) != output.status.code() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,32 +5,3 @@ fn run_goldentests_example() -> TestResult<()> {
     let config = TestConfig::new("python", "examples", "# ")?;
     config.run_tests()
 }
-
-#[test]
-fn test_overwrite() -> TestResult<()> {
-    // Test this without the filesystem? Is it worth it?
-
-    let overwrite_tests_dir = "overwrite_tests";
-    let overwrite_test = format!("{}/_gen.py", overwrite_tests_dir);
-    let test = "import sys; print('stdout'); print('stderr\\nwith\\nnewline\\n', file=sys.stderr);";
-
-    // Nuke the entire dir to makesure everything is the same for each test
-    std::fs::remove_dir_all(overwrite_tests_dir).unwrap();
-    std::fs::create_dir(overwrite_tests_dir).unwrap();
-    std::fs::write(&overwrite_test, test).unwrap();
-
-    let mut gen = TestConfig::new("python", overwrite_tests_dir, "# ")?;
-    gen.overwrite_tests = true;
-    assert!(
-        gen.run_tests().is_ok(),
-        "Expected the tests to pass but also overwrite"
-    );
-
-    // Now the tests should work, and the file should differ
-    let fixed_test = std::fs::read_to_string(&overwrite_test).unwrap();
-    assert_ne!(fixed_test, test, "The test file should have been updated");
-    
-    // Tests should now pass
-    let check = TestConfig::new("python", overwrite_tests_dir, "# ")?;
-    check.run_tests()
-}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,36 @@
-use goldentests::{ TestConfig, TestResult };
+use goldentests::{TestConfig, TestResult};
 
 #[test]
-fn run_goldentests() -> TestResult<()> {
+fn run_goldentests_example() -> TestResult<()> {
     let config = TestConfig::new("python", "examples", "# ")?;
     config.run_tests()
+}
+
+#[test]
+fn test_overwrite() -> TestResult<()> {
+    // Test this without the filesystem? Is it worth it?
+
+    let overwrite_tests_dir = "overwrite_tests";
+    let overwrite_test = format!("{}/_gen.py", overwrite_tests_dir);
+    let test = "import sys; print('stdout'); print('stderr\\nwith\\nnewline\\n', file=sys.stderr);";
+
+    // Nuke the entire dir to makesure everything is the same for each test
+    std::fs::remove_dir_all(overwrite_tests_dir).unwrap();
+    std::fs::create_dir(overwrite_tests_dir).unwrap();
+    std::fs::write(&overwrite_test, test).unwrap();
+
+    let mut gen = TestConfig::new("python", overwrite_tests_dir, "# ")?;
+    gen.overwrite_tests = true;
+    assert!(
+        gen.run_tests().is_ok(),
+        "Expected the tests to pass but also overwrite"
+    );
+
+    // Now the tests should work, and the file should differ
+    let fixed_test = std::fs::read_to_string(&overwrite_test).unwrap();
+    assert_ne!(fixed_test, test, "The test file should have been updated");
+    
+    // Tests should now pass
+    let check = TestConfig::new("python", overwrite_tests_dir, "# ")?;
+    check.run_tests()
 }


### PR DESCRIPTION
I was using this lovely library. Then I realized I made a minor change in a lot of my test files - no biggie - but now I want my tests to be updated. This program obviously knows what's wrong with my tests. It would be great if it could just, you know, do my work for me. So I added a flag for that.

Some things I've checked:
  - It's stable - running it multiple times outputs the same file
  - It manages to read the files it writes
  - It doesn't change files unnecessarily - if the test passes it won't touch the file
  - It only writes as much as it needs to - won't bother writing `stderr` if nothing is written to `stderr`.
  - I still want it :D

Some limitations:
 - Doesn't handle windows linen endings that well - there can be problems with it like the other code mentioned - but I have trouble testing that. So...
 - If the parser this tests is sensitive to newlines, it might add too many and break the test :(
 - The code style is not as neat as it could be, but I trust the community to give me feedback there ;)

Thanks for this lovely library and let me know if you want me to change anything. Have a good day!
