### PR TITLE
Allow testing a single file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,12 @@
-use crate::error::{TestError, TestResult};
-use colored::Colorize;
 use std::path::PathBuf;
 
 pub struct TestConfig {
     /// The binary path to your program, typically "target/debug/myprogram"
     pub binary_path: PathBuf,
 
-    /// The path to the subdirectory containing your tests. This subdirectory will be
-    /// searched recursively for all files.
+    /// The path to the directory containing your tests, or a single test file.
+    ///
+    /// If this is a directory, it will be searched recursively for all files.
     pub test_path: PathBuf,
 
     /// The sequence of characters starting at the beginning of a line that
@@ -112,7 +111,7 @@ impl TestConfig {
     /// If you want to change these default keywords you can also create a TestConfig
     /// via `TestConfig::with_custom_keywords` which will allow you to specify each.
     #[allow(unused)]
-    pub fn new<Binary, Tests>(binary_path: Binary, test_path: Tests, test_line_prefix: &str) -> TestResult<TestConfig>
+    pub fn new<Binary, Tests>(binary_path: Binary, test_path: Tests, test_line_prefix: &str) -> TestConfig
     where
         Binary: Into<PathBuf>,
         Tests: Into<PathBuf>,
@@ -145,41 +144,26 @@ impl TestConfig {
         test_stderr_prefix: &str,
         test_exit_status_prefix: &str,
         overwrite_tests: bool,
-    ) -> TestResult<TestConfig>
+    ) -> TestConfig
     where
         Binary: Into<PathBuf>,
         Tests: Into<PathBuf>,
     {
-        let (binary_path, test_path) = (binary_path.into(), test_path.into());
+        let binary_path = binary_path.into();
+        let test_path = test_path.into();
 
-        if !test_path.exists() {
-            eprintln!(
-                "{}",
-                format!("the given test path '{}' does not exist", test_path.display()).red()
-            );
+        let test_line_prefix = test_line_prefix.to_string();
+        let prefixed = |s| format!("{}{}", test_line_prefix, s);
 
-            Err(TestError::MissingTests(test_path))
-        } else if !test_path.is_dir() {
-            eprintln!(
-                "{}",
-                format!("the given test path '{}' is not a directory", test_path.display()).red()
-            );
-
-            Err(TestError::ExpectedDirectory(test_path))
-        } else {
-            let test_line_prefix = test_line_prefix.to_string();
-            let prefixed = |s| format!("{}{}", test_line_prefix, s);
-
-            Ok(TestConfig {
-                binary_path,
-                test_path,
-                test_args_prefix: prefixed(test_args_prefix),
-                test_stdout_prefix: prefixed(test_stdout_prefix),
-                test_stderr_prefix: prefixed(test_stderr_prefix),
-                test_exit_status_prefix: prefixed(test_exit_status_prefix),
-                test_line_prefix,
-                overwrite_tests,
-            })
+        TestConfig {
+            binary_path,
+            test_path,
+            test_args_prefix: prefixed(test_args_prefix),
+            test_stdout_prefix: prefixed(test_stdout_prefix),
+            test_stderr_prefix: prefixed(test_stderr_prefix),
+            test_exit_status_prefix: prefixed(test_exit_status_prefix),
+            test_line_prefix,
+            overwrite_tests,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,33 +1,9 @@
-use std::error::Error;
 use std::fmt;
 use std::path::PathBuf;
 
 use colored::Colorize;
 
-pub type TestResult<T> = Result<T, TestError>;
-
-#[derive(Debug)]
-pub enum TestError {
-    MissingTests(PathBuf),
-    ExpectedDirectory(PathBuf),
-    TestErrors,
-}
-
-impl fmt::Display for TestError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use TestError::*;
-        match self {
-            TestErrors => f.write_str("The expected test output differs"),
-            MissingTests(path) => write!(f, "Failed to locate test files {}", path.display()),
-            ExpectedDirectory(path) => {
-                let msg = "The path given for test files should be a directory ";
-                write!(f, "{}{}", msg, path.display())
-            }
-        }
-    }
-}
-
-impl Error for TestError {}
+pub type TestResult<T> = Result<T, ()>;
 
 // Inner test errors shouldn't be visible to the end-user,
 // they'll all be reported internally after running the tests

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@ struct Args {
     #[clap(help = "The program to run for each test file")]
     binary_path: PathBuf,
 
-    #[clap(help = "The directory to search for test files recursively within")]
-    test_directory: PathBuf,
+    #[clap(help = "The directory to search for test files recursively within, or a single file to test")]
+    test_path: PathBuf,
 
     #[clap(
         help = "Prefix string for test commands. This is usually the same as the comment syntax in the language you are testing. For example, in C this would be '// '"
@@ -55,22 +55,16 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    let config = match TestConfig::with_custom_keywords(
+    let config = TestConfig::with_custom_keywords(
         args.binary_path,
-        args.test_directory,
+        args.test_path,
         &args.test_prefix,
         &args.args_prefix,
         &args.stdout_prefix,
         &args.stderr_prefix,
         &args.exit_status_prefix,
         args.overwrite,
-    ) {
-        Ok(config) => config,
-        Err(error) => {
-            eprintln!("error: {}", error);
-            return;
-        }
-    };
+    );
 
     config.run_tests().unwrap_or_else(|_| std::process::exit(1));
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,6 +2,6 @@ use goldentests::{TestConfig, TestResult};
 
 #[test]
 fn run_goldentests_example() -> TestResult<()> {
-    let config = TestConfig::new("python", "examples", "# ")?;
+    let config = TestConfig::new("python", "examples", "# ");
     config.run_tests()
 }


### PR DESCRIPTION
Update the file path argument handling to allow testing a single file.

Error checking during config generation is removed, as we have to check for missing file/directory errors anyway while running the tests, and checking the files ahead of time isn't that useful as the file or directory can disappear between the config generation and running the tests.