### PR TITLE
Remove redundant call to String::trim before parsing test args

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -293,14 +293,8 @@ impl TestConfig {
                 #[cfg(feature = "progress-bar")]
                 progress.inc(1);
                 let test = parse_test(&file, self)?;
-                let mut args = vec![];
-
-                // Avoid pushing an empty '' arg at the beginning
-                let trimmed_args = test.command_line_args.trim();
-                if !trimmed_args.is_empty() {
-                    args = shlex::split(trimmed_args)
-                        .ok_or_else(|| InnerTestError::ErrorParsingArgs(file.clone(), trimmed_args.to_owned()))?;
-                }
+                let mut args = shlex::split(&test.command_line_args)
+                    .ok_or_else(|| InnerTestError::ErrorParsingArgs(file.clone(), test.command_line_args.to_owned()))?;
 
                 args.push(test.path.to_string_lossy().to_string());
 


### PR DESCRIPTION
`shlex::split` doesn't generate empty strings when the input has initial or trailing whitespace, so the comment is not right and the trim call can be removed.

`shlex::split` example:

    fn main() {
        println!("{:?}", shlex::split("").unwrap());
        println!("{:?}", shlex::split("      ").unwrap());
        println!("{:?}", shlex::split("   a  ").unwrap());
    }

When run with version 1.1.0 (the version specified in golden-tests Cargo.toml) and the latest version 1.3.0 this prints:

    []
    []
    ["a"]