### PR TITLE
Add support for passing command line arguments after the program file path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,9 +17,14 @@ pub struct TestConfig {
     pub test_line_prefix: String,
 
     /// The "args:" keyword used while parsing tests. Anything after
-    /// `test_line_prefix + test_args_prefix` is read in as a space-delimited
-    /// argument to the program.
+    /// `test_line_prefix + test_args_prefix` is read in as shell arguments to
+    /// the program, passed before the test file path.
     pub test_args_prefix: String,
+
+    /// The "args after:" keyword used while parsing tests. Anything after
+    /// `test_line_prefix + test_args_after_prefix` is read in as shell
+    /// arguments to the program, passed after the test file path.
+    pub test_args_after_prefix: String,
 
     /// The "expected stdout:" keyword used while parsing tests. Any line starting
     /// with `test_line_prefix` after a line starting with `test_line_prefix + test_stdout_prefix`
@@ -121,6 +126,7 @@ impl TestConfig {
             test_path,
             test_line_prefix,
             "args:",
+            "args after:",
             "expected stdout:",
             "expected stderr:",
             "expected exit status:",
@@ -140,6 +146,7 @@ impl TestConfig {
         test_path: Tests,
         test_line_prefix: &str,
         test_args_prefix: &str,
+        test_args_after_prefix: &str,
         test_stdout_prefix: &str,
         test_stderr_prefix: &str,
         test_exit_status_prefix: &str,
@@ -159,6 +166,7 @@ impl TestConfig {
             binary_path,
             test_path,
             test_args_prefix: prefixed(test_args_prefix),
+            test_args_after_prefix: prefixed(test_args_after_prefix),
             test_stdout_prefix: prefixed(test_stdout_prefix),
             test_stderr_prefix: prefixed(test_stderr_prefix),
             test_exit_status_prefix: prefixed(test_exit_status_prefix),

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,19 @@ struct Args {
     )]
     test_prefix: String,
 
-    #[clap(long, default_value = "args:", help = "The program to run for each test file")]
+    #[clap(
+        long,
+        default_value = "args:",
+        help = "Prefix string for the command line arguments to be passed to the command, before the program file path."
+    )]
     args_prefix: String,
+
+    #[clap(
+        long,
+        default_value = "args after:",
+        help = "Prefix string for the command line arguments to be passed to the command, after the program file path."
+    )]
+    args_after_prefix: String,
 
     #[clap(
         long,
@@ -60,6 +71,7 @@ fn main() {
         args.test_path,
         &args.test_prefix,
         &args.args_prefix,
+        &args.args_after_prefix,
         &args.stdout_prefix,
         &args.stderr_prefix,
         &args.exit_status_prefix,


### PR DESCRIPTION
This addresses #10 in a simple way: instead of making argument order
configurable, we add a new test configuration, by default with the "args
after:" prefix (configurable via command line). The arguments listed in this
configuration are passed to the test command *after* the test file path.

For example:

    print('hi')
    
    # args: -c 'import sys; print(sys.argv)'
    # args after: a b
    # expected stdout: ['-c', 'test.py', 'a', 'b']

Now passes when tested as:

    goldentests python3 test.py '# '

Closes #10.