### PR TITLE
Implement glob option for test config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +33,16 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -142,11 +161,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "goldentests"
 version = "1.4.1"
 dependencies = [
  "clap",
  "colored",
+ "globset",
  "indicatif",
  "rayon",
  "serde",
@@ -238,6 +271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +355,23 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ toml = "0.9.5"
 serde = { version = "1.0", features = ["derive"] }
 rayon = { version = "1.5.1", optional = true }
 indicatif = { version = "0.18.0", optional = true }
+globset = "0.4.18"
 
 # clap is only needed for the goldentest binary,
 # enabling it will have no effect on the library version

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ Since golden-tests requires a lot of configuration to run, you can optionally pr
 binary_path = "/bin/python"
 test_path = "path-to-tests"
 test_line_prefix = "# "
+glob = "*.py"
 ```
+
+The `glob` argument is optional but useful to only run files of a particular file suffix.
 
 #### As a rust integration test
 

--- a/goldentests.toml
+++ b/goldentests.toml
@@ -1,3 +1,4 @@
 binary_path = "python"
 test_path = "examples"
 test_line_prefix = "# "
+glob = "*.py"

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,10 @@ pub struct TestConfig {
     /// If this is a directory, it will be searched recursively for all files.
     pub test_path: PathBuf,
 
+    /// Only test files in the path that match the glob. Multiple globs may be used.
+    #[serde(default)]
+    pub glob: Vec<String>,
+
     /// The sequence of characters starting at the beginning of a line that
     /// all test options should be prefixed with. This is typically a comment
     /// in your language. For example, if we had a C like language we could
@@ -143,7 +147,12 @@ impl TestConfig {
     /// If you want to change these default keywords you can also create a TestConfig
     /// via `TestConfig::with_custom_keywords` which will allow you to specify each.
     #[allow(unused)]
-    pub fn new<Binary, Tests>(binary_path: Binary, test_path: Tests, test_line_prefix: &str) -> TestConfig
+    pub fn new<Binary, Tests>(
+        binary_path: Binary,
+        test_path: Tests,
+        glob: Vec<String>,
+        test_line_prefix: &str,
+    ) -> TestConfig
     where
         Binary: Into<PathBuf>,
         Tests: Into<PathBuf>,
@@ -151,6 +160,7 @@ impl TestConfig {
         TestConfig::with_custom_keywords(
             binary_path,
             test_path,
+            glob,
             test_line_prefix,
             "args:",
             "args after:",
@@ -189,6 +199,7 @@ impl TestConfig {
     pub fn with_custom_keywords<Binary, Tests>(
         binary_path: Binary,
         test_path: Tests,
+        glob: Vec<String>,
         test_line_prefix: &str,
         test_args_prefix: &str,
         test_args_after_prefix: &str,
@@ -210,6 +221,7 @@ impl TestConfig {
         TestConfig {
             binary_path,
             test_path,
+            glob,
             test_args_prefix: prefixed(test_args_prefix),
             test_args_after_prefix: prefixed(test_args_after_prefix),
             test_stdout_prefix: prefixed(test_stdout_prefix),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,41 @@
+use std::fmt;
+use std::marker::PhantomData;
 use std::path::PathBuf;
 
+use serde::de::{self, Deserializer, SeqAccess, Visitor};
 use serde::Deserialize;
+
+fn string_or_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StringOrVec(PhantomData<Vec<String>>);
+
+    impl<'de> Visitor<'de> for StringOrVec {
+        type Value = Vec<String>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a string or a list of strings")
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            Ok(vec![v.to_string()])
+        }
+
+        fn visit_string<E: de::Error>(self, v: String) -> Result<Self::Value, E> {
+            Ok(vec![v])
+        }
+
+        fn visit_seq<S>(self, seq: S) -> Result<Self::Value, S::Error>
+        where
+            S: SeqAccess<'de>,
+        {
+            Deserialize::deserialize(de::value::SeqAccessDeserializer::new(seq))
+        }
+    }
+
+    deserializer.deserialize_any(StringOrVec(PhantomData))
+}
 
 const DEFAULT_ARGS_PREFIX: fn() -> String = || "args:".to_string();
 const DEFAULT_ARGS_AFTER_PREFIX: fn() -> String = || "args after:".to_string();
@@ -19,7 +54,7 @@ pub struct TestConfig {
     pub test_path: PathBuf,
 
     /// Only test files in the path that match the glob. Multiple globs may be used. A glob may be negated with a '!' prefix.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "string_or_vec")]
     pub glob: Vec<String>,
 
     /// The sequence of characters starting at the beginning of a line that
@@ -147,11 +182,7 @@ impl TestConfig {
     /// If you want to change these default keywords you can also create a TestConfig
     /// via `TestConfig::with_custom_keywords` which will allow you to specify each.
     #[allow(unused)]
-    pub fn new<Binary, Tests>(
-        binary_path: Binary,
-        test_path: Tests,
-        test_line_prefix: &str,
-    ) -> TestConfig
+    pub fn new<Binary, Tests>(binary_path: Binary, test_path: Tests, test_line_prefix: &str) -> TestConfig
     where
         Binary: Into<PathBuf>,
         Tests: Into<PathBuf>,
@@ -159,7 +190,7 @@ impl TestConfig {
         TestConfig::with_custom_keywords(
             binary_path,
             test_path,
-            glob: Vec::new(),
+            Vec::new(),
             test_line_prefix,
             "args:",
             "args after:",

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,8 @@ pub struct TestConfig {
     /// If this is a directory, it will be searched recursively for all files.
     pub test_path: PathBuf,
 
-    /// Only test files in the path that match the glob. Multiple globs may be used.
+    /// Only test files in the path that match the glob. Multiple globs may be used. A glob may be
+    /// negated with a '!' prefix.
     #[serde(default)]
     pub glob: Vec<String>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,8 +18,7 @@ pub struct TestConfig {
     /// If this is a directory, it will be searched recursively for all files.
     pub test_path: PathBuf,
 
-    /// Only test files in the path that match the glob. Multiple globs may be used. A glob may be
-    /// negated with a '!' prefix.
+    /// Only test files in the path that match the glob. Multiple globs may be used. A glob may be negated with a '!' prefix.
     #[serde(default)]
     pub glob: Vec<String>,
 
@@ -112,7 +111,7 @@ impl TestConfig {
     ///
     /// ```rust
     /// use goldentests::TestConfig;
-    /// let config = TestConfig::new("target/debug/my-compiler", "examples/goldentests", "// ");
+    /// let config = TestConfig::new("target/debug/my-compiler", "examples/goldentests", vec![], "// ");
     /// ```
     ///
     /// This will give us the default keywords when parsing our test files which allows

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,7 +111,7 @@ impl TestConfig {
     ///
     /// ```rust
     /// use goldentests::TestConfig;
-    /// let config = TestConfig::new("target/debug/my-compiler", "examples/goldentests", vec![], "// ");
+    /// let config = TestConfig::new("target/debug/my-compiler", "examples/goldentests", "// ");
     /// ```
     ///
     /// This will give us the default keywords when parsing our test files which allows

--- a/src/config.rs
+++ b/src/config.rs
@@ -150,7 +150,6 @@ impl TestConfig {
     pub fn new<Binary, Tests>(
         binary_path: Binary,
         test_path: Tests,
-        glob: Vec<String>,
         test_line_prefix: &str,
     ) -> TestConfig
     where

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,7 +159,7 @@ impl TestConfig {
         TestConfig::with_custom_keywords(
             binary_path,
             test_path,
-            glob,
+            glob: Vec::new(),
             test_line_prefix,
             "args:",
             "args after:",

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -1,0 +1,70 @@
+use std::path::Path;
+
+use globset::{Glob, GlobSet, GlobSetBuilder};
+
+use crate::error::TestResult;
+
+#[derive(Debug, Default)]
+pub struct Globs {
+    include: Option<GlobSet>,
+    exclude: Option<GlobSet>,
+}
+
+impl Globs {
+    pub fn new(glob_strings: &[String]) -> TestResult<Globs> {
+        let mut globs = Globs::default();
+
+        let mut include_builder = GlobSetBuilder::new();
+        let mut exclude_builder = GlobSetBuilder::new();
+
+        println!("globs: {glob_strings:?}");
+        for glob in glob_strings {
+            println!("glob: {glob}");
+            match glob.strip_prefix('!') {
+                Some(glob) => {
+                    exclude_builder.add(build_glob(glob)?);
+                }
+                None => {
+                    include_builder.add(build_glob(glob)?);
+                }
+            }
+        }
+
+        let include = build_glob_set(include_builder)?;
+        let exclude = build_glob_set(exclude_builder)?;
+
+        if !include.is_empty() {
+            globs.include = Some(include);
+        }
+
+        if !exclude.is_empty() {
+            globs.exclude = Some(exclude);
+        }
+        Ok(globs)
+    }
+
+    pub fn is_match(&self, path: &Path) -> bool {
+        let mut match_ = true;
+        if let Some(include_set) = &self.include {
+            match_ &= include_set.is_match(path);
+        }
+        if let Some(exclude_set) = &self.exclude {
+            match_ &= !exclude_set.is_match(path);
+        }
+        match_
+    }
+}
+
+fn build_glob(s: &str) -> TestResult<Glob> {
+    Glob::new(s).map_err(|err| {
+        eprintln!("Invalid glob: {}", err);
+        ()
+    })
+}
+
+fn build_glob_set(builder: GlobSetBuilder) -> TestResult<GlobSet> {
+    builder.build().map_err(|err| {
+        eprintln!("Unable to build glob set: {}", err);
+        ()
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod config;
 mod config_file;
 mod diff_printer;
 pub mod error;
+pub mod glob;
 mod runner;
 
 pub use config::TestConfig;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ struct Args {
     #[clap(
         long,
         short,
-        help = "Only test files in the path that match the glob. Multiple globs may be used."
+        help = "Only test files in the path that match the glob. Multiple globs may be used. A glob may be negated with a '!' prefix."
     )]
     glob: Vec<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod config;
 mod config_file;
 mod diff_printer;
 mod error;
+mod glob;
 mod runner;
 
 use crate::config::TestConfig;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,13 @@ struct Args {
     test_path: PathBuf,
 
     #[clap(
+        long,
+        short,
+        help = "Only test files in the path that match the glob. Multiple globs may be used."
+    )]
+    glob: Vec<String>,
+
+    #[clap(
         help = "Prefix string for test commands. This is usually the same as the comment syntax in the language you are testing. For example, in C this would be '// '"
     )]
     test_prefix: String,
@@ -124,6 +131,7 @@ impl Args {
         TestConfig {
             binary_path: self.binary_path,
             test_path: self.test_path,
+            glob: self.glob.clone(),
             test_line_prefix: self.test_prefix,
             test_args_prefix: self.args_prefix,
             test_args_after_prefix: self.args_after_prefix,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 
 use colored::Colorize;
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use similar::TextDiff;
 
 #[cfg(feature = "parallel")]
@@ -41,7 +42,7 @@ enum TestParseState {
     ReadingExpectedStderr,
 }
 
-fn find_tests(test_path: &Path) -> (Vec<PathBuf>, Vec<InnerTestError>) {
+fn find_tests(test_path: &Path, glob_set: Option<&GlobSet>) -> (Vec<PathBuf>, Vec<InnerTestError>) {
     let mut tests = vec![];
     let mut errors = vec![];
 
@@ -61,14 +62,14 @@ fn find_tests(test_path: &Path) -> (Vec<PathBuf>, Vec<InnerTestError>) {
             };
 
             if path.is_dir() {
-                let (mut more_tests, mut more_errors) = find_tests(&path);
+                let (mut more_tests, mut more_errors) = find_tests(&path, glob_set);
                 tests.append(&mut more_tests);
                 errors.append(&mut more_errors);
-            } else {
+            } else if glob_set.map(|g| g.is_match(&path)).unwrap_or(true) {
                 tests.push(path);
             }
         }
-    } else {
+    } else if glob_set.map(|g| g.is_match(test_path)).unwrap_or(true) {
         tests.push(test_path.into());
     }
 
@@ -355,7 +356,30 @@ impl TestConfig {
     /// Recurse through all the files in self.path, parse them all,
     /// and run the target program with the arguments specified in the file.
     pub fn run_tests(&self) -> TestResult<()> {
-        let (tests, path_errors) = find_tests(&self.test_path);
+        let glob_set = if self.glob.is_empty() {
+            None
+        } else {
+            let mut builder = GlobSetBuilder::new();
+            for glob in &self.glob {
+                let glob = match Glob::new(glob) {
+                    Ok(glob) => glob,
+                    Err(err) => {
+                        eprintln!("Invalid glob: {}", err);
+                        return Err(());
+                    }
+                };
+                builder.add(glob);
+            }
+            match builder.build() {
+                Err(err) => {
+                    eprintln!("Unable to build glob set: {}", err);
+                    return Err(());
+                }
+                Ok(glob_set) => Some(glob_set),
+            }
+        };
+
+        let (tests, path_errors) = find_tests(&self.test_path, glob_set.as_ref());
         let outputs = self.test_all(tests);
 
         for error in path_errors {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,10 +2,10 @@ use crate::{
     config::TestConfig,
     diff_printer::DiffPrinter,
     error::{InnerTestError, TestResult},
+    glob::Globs,
 };
 
 use colored::Colorize;
-use globset::{Glob, GlobSet, GlobSetBuilder};
 use similar::TextDiff;
 
 #[cfg(feature = "parallel")]
@@ -42,25 +42,6 @@ enum TestParseState {
     ReadingExpectedStderr,
 }
 
-#[derive(Debug, Default)]
-struct Globs {
-    include: Option<GlobSet>,
-    exclude: Option<GlobSet>,
-}
-
-impl Globs {
-    fn is_match<P: AsRef<Path>>(&self, path: &P) -> bool {
-        let mut match_ = true;
-        if let Some(include_set) = &self.include {
-            match_ &= include_set.is_match(path);
-        }
-        if let Some(exclude_set) = &self.exclude {
-            match_ &= !exclude_set.is_match(path);
-        }
-        match_
-    }
-}
-
 fn find_tests(test_path: &Path, globs: &Globs) -> (Vec<PathBuf>, Vec<InnerTestError>) {
     let mut tests = vec![];
     let mut errors = vec![];
@@ -85,6 +66,7 @@ fn find_tests(test_path: &Path, globs: &Globs) -> (Vec<PathBuf>, Vec<InnerTestEr
                 tests.append(&mut more_tests);
                 errors.append(&mut more_errors);
             } else if globs.is_match(&path) {
+                println!("globs match {path:?}: globs: {globs:?}");
                 tests.push(path);
             }
         }
@@ -375,33 +357,7 @@ impl TestConfig {
     /// Recurse through all the files in self.path, parse them all,
     /// and run the target program with the arguments specified in the file.
     pub fn run_tests(&self) -> TestResult<()> {
-        let mut globs = Globs::default();
-
-        let mut include_builder = GlobSetBuilder::new();
-        let mut exclude_builder = GlobSetBuilder::new();
-
-        for glob in &self.glob {
-            match glob.strip_prefix('!') {
-                Some(glob) => {
-                    exclude_builder.add(build_glob(glob)?);
-                }
-                None => {
-                    include_builder.add(build_glob(glob)?);
-                }
-            }
-        }
-
-        let include = build_glob_set(include_builder)?;
-        let exclude = build_glob_set(exclude_builder)?;
-
-        if !include.is_empty() {
-            globs.include = Some(include);
-        }
-
-        if !exclude.is_empty() {
-            globs.exclude = Some(exclude);
-        }
-
+        let globs = Globs::new(&self.glob)?;
         let (tests, path_errors) = find_tests(&self.test_path, &globs);
         let outputs = self.test_all(tests);
 
@@ -467,26 +423,6 @@ impl TestConfig {
             Err(())
         } else {
             Ok(())
-        }
-    }
-}
-
-fn build_glob(s: &str) -> TestResult<Glob> {
-    match Glob::new(s) {
-        Ok(glob) => Ok(glob),
-        Err(err) => {
-            eprintln!("Invalid glob: {}", err);
-            Err(())
-        }
-    }
-}
-
-fn build_glob_set(builder: GlobSetBuilder) -> TestResult<GlobSet> {
-    match builder.build() {
-        Ok(glob_set) => Ok(glob_set),
-        Err(err) => {
-            eprintln!("Unable to build glob set: {}", err);
-            Err(())
         }
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -42,7 +42,26 @@ enum TestParseState {
     ReadingExpectedStderr,
 }
 
-fn find_tests(test_path: &Path, glob_set: Option<&GlobSet>) -> (Vec<PathBuf>, Vec<InnerTestError>) {
+#[derive(Debug, Default)]
+struct Globs {
+    include: Option<GlobSet>,
+    exclude: Option<GlobSet>,
+}
+
+impl Globs {
+    fn is_match<P: AsRef<Path>>(&self, path: &P) -> bool {
+        let mut match_ = true;
+        if let Some(include_set) = &self.include {
+            match_ &= include_set.is_match(path);
+        }
+        if let Some(exclude_set) = &self.exclude {
+            match_ &= !exclude_set.is_match(path);
+        }
+        match_
+    }
+}
+
+fn find_tests(test_path: &Path, globs: &Globs) -> (Vec<PathBuf>, Vec<InnerTestError>) {
     let mut tests = vec![];
     let mut errors = vec![];
 
@@ -62,14 +81,14 @@ fn find_tests(test_path: &Path, glob_set: Option<&GlobSet>) -> (Vec<PathBuf>, Ve
             };
 
             if path.is_dir() {
-                let (mut more_tests, mut more_errors) = find_tests(&path, glob_set);
+                let (mut more_tests, mut more_errors) = find_tests(&path, globs);
                 tests.append(&mut more_tests);
                 errors.append(&mut more_errors);
-            } else if glob_set.map(|g| g.is_match(&path)).unwrap_or(true) {
+            } else if globs.is_match(&path) {
                 tests.push(path);
             }
         }
-    } else if glob_set.map(|g| g.is_match(test_path)).unwrap_or(true) {
+    } else if globs.is_match(&test_path) {
         tests.push(test_path.into());
     }
 
@@ -356,30 +375,34 @@ impl TestConfig {
     /// Recurse through all the files in self.path, parse them all,
     /// and run the target program with the arguments specified in the file.
     pub fn run_tests(&self) -> TestResult<()> {
-        let glob_set = if self.glob.is_empty() {
-            None
-        } else {
-            let mut builder = GlobSetBuilder::new();
-            for glob in &self.glob {
-                let glob = match Glob::new(glob) {
-                    Ok(glob) => glob,
-                    Err(err) => {
-                        eprintln!("Invalid glob: {}", err);
-                        return Err(());
-                    }
-                };
-                builder.add(glob);
-            }
-            match builder.build() {
-                Err(err) => {
-                    eprintln!("Unable to build glob set: {}", err);
-                    return Err(());
-                }
-                Ok(glob_set) => Some(glob_set),
-            }
-        };
+        let mut globs = Globs::default();
 
-        let (tests, path_errors) = find_tests(&self.test_path, glob_set.as_ref());
+        let mut include_builder = GlobSetBuilder::new();
+        let mut exclude_builder = GlobSetBuilder::new();
+
+        for glob in &self.glob {
+            match glob.strip_prefix('!') {
+                Some(glob) => {
+                    exclude_builder.add(build_glob(glob)?);
+                }
+                None => {
+                    include_builder.add(build_glob(glob)?);
+                }
+            }
+        }
+
+        let include = build_glob_set(include_builder)?;
+        let exclude = build_glob_set(exclude_builder)?;
+
+        if !include.is_empty() {
+            globs.include = Some(include);
+        }
+
+        if !exclude.is_empty() {
+            globs.exclude = Some(exclude);
+        }
+
+        let (tests, path_errors) = find_tests(&self.test_path, &globs);
         let outputs = self.test_all(tests);
 
         for error in path_errors {
@@ -444,6 +467,26 @@ impl TestConfig {
             Err(())
         } else {
             Ok(())
+        }
+    }
+}
+
+fn build_glob(s: &str) -> TestResult<Glob> {
+    match Glob::new(s) {
+        Ok(glob) => Ok(glob),
+        Err(err) => {
+            eprintln!("Invalid glob: {}", err);
+            Err(())
+        }
+    }
+}
+
+fn build_glob_set(builder: GlobSetBuilder) -> TestResult<GlobSet> {
+    match builder.build() {
+        Ok(glob_set) => Ok(glob_set),
+        Err(err) => {
+            eprintln!("Unable to build glob set: {}", err);
+            Err(())
         }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,6 +2,6 @@ use goldentests::{TestConfig, TestResult};
 
 #[test]
 fn run_goldentests_example() -> TestResult<()> {
-    let config = TestConfig::new("python", "examples", vec![], "# ");
+    let config = TestConfig::new("python", "examples", "# ");
     config.run_tests()
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,6 +2,6 @@ use goldentests::{TestConfig, TestResult};
 
 #[test]
 fn run_goldentests_example() -> TestResult<()> {
-    let config = TestConfig::new("python", "examples", "# ");
+    let config = TestConfig::new("python", "examples", vec![], "# ");
     config.run_tests()
 }


### PR DESCRIPTION
Follow-up to https://github.com/jfecher/golden-tests/pull/23 which moves things around and adds the ability to specify a single string into an array for glob in the config.

Note that `--glob` is not a CLI arg. It must be specified in the `goldentests.toml` or directly when constructed in rust code.